### PR TITLE
Impl Deref to allow access to inner stream

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 //! ```
 use std::{
     io::{self, Read, Write},
+    ops::{Deref, DerefMut},
     time::Duration,
 };
 
@@ -118,5 +119,25 @@ where
 
     fn flush(&mut self) -> io::Result<()> {
         self.stream.flush()
+    }
+}
+
+impl<S> Deref for Limiter<S>
+where
+    S: Read + Write,
+{
+    type Target = S;
+
+    fn deref(&self) -> &Self::Target {
+        &self.stream
+    }
+}
+
+impl<S> DerefMut for Limiter<S>
+where
+    S: Read + Write,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.stream
     }
 }


### PR DESCRIPTION
This allows for an underlying interface to be exposed. For my particular use-case, it can be usefull to do things like set-non blocking, get addresses, etc. on our TcpStreams