### PR TITLE
Add limit to bucket size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! use std::fs::File;
 //!
 //! let mut file = File::open("tests/resources/test.txt").unwrap();
-//! let mut limiter = Limiter::new(file, 1, Duration::from_secs(1));
+//! let mut limiter = Limiter::new(file, 1, Duration::from_secs(1), 1);
 //! let mut buf = [0u8; 10];
 //! let now = std::time::Instant::now();
 //! limiter.read(&mut buf).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,12 @@ where
     /// - `window_time`: The time window in which `window_length` bytes can be read or written.
     ///
     /// We initialize the limiter as if one period has already passed so that the first read/write is instant.
-    pub fn new(stream: S, window_length: u128, window_time: Duration, bucket_size: usize) -> Limiter<S> {
+    pub fn new(
+        stream: S,
+        window_length: u128,
+        window_time: Duration,
+        bucket_size: usize,
+    ) -> Limiter<S> {
         Limiter {
             window_length,
             window_time,
@@ -65,11 +70,14 @@ where
         let mut read = 0;
         let buf_len = buf.len();
         while read < buf_len {
-            let nb_bytes_readable = std::cmp::min(std::cmp::min(
-                ((self.last_read_check.elapsed().as_nanos() / self.window_time.as_nanos())
-                    * self.window_length) as usize,
-                buf_len,
-            ), self.bucket_size);
+            let nb_bytes_readable = std::cmp::min(
+                std::cmp::min(
+                    ((self.last_read_check.elapsed().as_nanos() / self.window_time.as_nanos())
+                        * self.window_length) as usize,
+                    buf_len,
+                ),
+                self.bucket_size,
+            );
             if nb_bytes_readable < std::cmp::min(buf_len, self.window_length as usize) {
                 std::thread::sleep(self.window_time);
                 continue;

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -7,7 +7,7 @@ mod tests {
     #[test]
     fn one_byte_each_second() {
         let file = File::open("tests/resources/test.txt").unwrap();
-        let mut limiter = Limiter::new(file, 1, Duration::from_secs(1));
+        let mut limiter = Limiter::new(file, 1, Duration::from_secs(1), 10);
         let now = std::time::Instant::now();
         let mut buf = [0u8; 10];
         limiter.read(&mut buf).unwrap();
@@ -17,7 +17,7 @@ mod tests {
     #[test]
     fn one_byte_each_two_hundreds_fifty_millis() {
         let file = File::open("tests/resources/test.txt").unwrap();
-        let mut limiter = Limiter::new(file, 1, Duration::from_millis(250));
+        let mut limiter = Limiter::new(file, 1, Duration::from_millis(250), 10);
         let now = std::time::Instant::now();
         let mut buf = [0u8; 10];
         limiter.read(&mut buf).unwrap();
@@ -27,7 +27,7 @@ mod tests {
     #[test]
     fn two_byte_each_second() {
         let file = File::open("tests/resources/test.txt").unwrap();
-        let mut limiter = Limiter::new(file, 2, Duration::from_secs(1));
+        let mut limiter = Limiter::new(file, 2, Duration::from_secs(1), 10);
         let now = std::time::Instant::now();
         let mut buf = [0u8; 10];
         limiter.read(&mut buf).unwrap();
@@ -37,7 +37,7 @@ mod tests {
     #[test]
     fn read_instant() {
         let file = File::open("tests/resources/test.txt").unwrap();
-        let mut limiter = Limiter::new(file, 10, Duration::from_secs(1));
+        let mut limiter = Limiter::new(file, 10, Duration::from_secs(1), 10);
         let now = std::time::Instant::now();
         let mut buf = [0u8; 10];
         limiter.read(&mut buf).unwrap();
@@ -47,7 +47,7 @@ mod tests {
     #[test]
     fn read_instant_on_bigger_buffer() {
         let file = File::open("tests/resources/test.txt").unwrap();
-        let mut limiter = Limiter::new(file, 100, Duration::from_secs(1));
+        let mut limiter = Limiter::new(file, 100, Duration::from_secs(1), 1000);
         let now = std::time::Instant::now();
         let mut buf = [0u8; 1000];
         limiter.read(&mut buf).unwrap();
@@ -57,7 +57,7 @@ mod tests {
     #[test]
     fn test_burst() {
         let file = File::open("tests/resources/test.txt").unwrap();
-        let mut limiter = Limiter::new(file, 1, Duration::from_secs(1));
+        let mut limiter = Limiter::new(file, 1, Duration::from_secs(1), 1);
         // Read a first byte of 1 byte. Should be instant
         let now = std::time::Instant::now();
         let mut buf = [0u8; 1];
@@ -76,7 +76,7 @@ mod tests {
     #[test]
     fn read_the_whole_file() {
         let file = File::open("tests/resources/little.txt").unwrap();
-        let mut limiter = Limiter::new(file, 1, Duration::from_secs(1));
+        let mut limiter = Limiter::new(file, 1, Duration::from_secs(1), 5);
         let now = std::time::Instant::now();
         let mut buf = [0u8; 5].to_vec();
         limiter.read_to_end(&mut buf).unwrap();
@@ -86,7 +86,7 @@ mod tests {
     #[test]
     fn tenko_limit() {
         let file = File::open("tests/resources/big.txt").unwrap();
-        let mut limiter = Limiter::new(file, 10 * 1024, Duration::from_secs(1));
+        let mut limiter = Limiter::new(file, 10 * 1024, Duration::from_secs(1), 12*1024);
         let now = std::time::Instant::now();
         let mut buf = [0u8; 11 * 1024];
         limiter.read(&mut buf).unwrap();
@@ -96,11 +96,21 @@ mod tests {
     #[test]
     fn splitted_read() {
         let file = File::open("tests/resources/big.txt").unwrap();
-        let mut limiter = Limiter::new(file, 11, Duration::from_nanos((1000 * 1000 * 1000) / 1024));
+        let mut limiter = Limiter::new(file, 11, Duration::from_nanos((1000 * 1000 * 1000) / 1024), 12*1024);
         let now = std::time::Instant::now();
         let mut buf = [0u8; 8];
         limiter.read(&mut buf).unwrap();
         let mut buf = [0u8; (11 * 1024) - 8];
+        limiter.read(&mut buf).unwrap();
+        assert_eq!(now.elapsed().as_secs(), 1);
+    }
+
+    #[test]
+    fn test_bucket_full() {
+        let file = File::open("tests/resources/test.txt").unwrap();
+        let mut limiter = Limiter::new(file, 1024, Duration::from_secs(1), 10);
+        let now = std::time::Instant::now();
+        let mut buf = [0u8; 15];
         limiter.read(&mut buf).unwrap();
         assert_eq!(now.elapsed().as_secs(), 1);
     }

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -57,7 +57,7 @@ mod tests {
     #[test]
     fn test_burst() {
         let file = File::open("tests/resources/test.txt").unwrap();
-        let mut limiter = Limiter::new(file, 1, Duration::from_secs(1), 1);
+        let mut limiter = Limiter::new(file, 1, Duration::from_secs(1), 9);
         // Read a first byte of 1 byte. Should be instant
         let now = std::time::Instant::now();
         let mut buf = [0u8; 1];
@@ -119,4 +119,6 @@ mod tests {
         limiter.read(&mut buf).unwrap();
         assert_eq!(now.elapsed().as_secs(), 1);
     }
+
+    // TODO    Add test changing the bucket size between 2 reads
 }

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -86,7 +86,7 @@ mod tests {
     #[test]
     fn tenko_limit() {
         let file = File::open("tests/resources/big.txt").unwrap();
-        let mut limiter = Limiter::new(file, 10 * 1024, Duration::from_secs(1), 12*1024);
+        let mut limiter = Limiter::new(file, 10 * 1024, Duration::from_secs(1), 12 * 1024);
         let now = std::time::Instant::now();
         let mut buf = [0u8; 11 * 1024];
         limiter.read(&mut buf).unwrap();
@@ -96,7 +96,12 @@ mod tests {
     #[test]
     fn splitted_read() {
         let file = File::open("tests/resources/big.txt").unwrap();
-        let mut limiter = Limiter::new(file, 11, Duration::from_nanos((1000 * 1000 * 1000) / 1024), 12*1024);
+        let mut limiter = Limiter::new(
+            file,
+            11,
+            Duration::from_nanos((1000 * 1000 * 1000) / 1024),
+            12 * 1024,
+        );
         let now = std::time::Instant::now();
         let mut buf = [0u8; 8];
         limiter.read(&mut buf).unwrap();

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -7,7 +7,7 @@ mod tests {
     #[test]
     fn one_byte_each_second() {
         let file = tempfile().unwrap();
-        let mut limiter = Limiter::new(file, 1, Duration::from_secs(1));
+        let mut limiter = Limiter::new(file, 1, Duration::from_secs(1), 10);
         let now = std::time::Instant::now();
         let buf = [0u8; 10];
         limiter.write(&buf).unwrap();
@@ -17,7 +17,7 @@ mod tests {
     #[test]
     fn one_byte_each_two_hundreds_fifty_millis() {
         let file = tempfile().unwrap();
-        let mut limiter = Limiter::new(file, 1, Duration::from_millis(250));
+        let mut limiter = Limiter::new(file, 1, Duration::from_millis(250), 10);
         let now = std::time::Instant::now();
         let buf = [0u8; 10];
         limiter.write(&buf).unwrap();
@@ -27,7 +27,7 @@ mod tests {
     #[test]
     fn two_byte_each_second() {
         let file = tempfile().unwrap();
-        let mut limiter = Limiter::new(file, 2, Duration::from_secs(1));
+        let mut limiter = Limiter::new(file, 2, Duration::from_secs(1), 10);
         let now = std::time::Instant::now();
         let buf = [0u8; 10];
         limiter.write(&buf).unwrap();
@@ -37,7 +37,7 @@ mod tests {
     #[test]
     fn write_instant() {
         let file = tempfile().unwrap();
-        let mut limiter = Limiter::new(file, 10, Duration::from_secs(1));
+        let mut limiter = Limiter::new(file, 10, Duration::from_secs(1), 10);
         let now = std::time::Instant::now();
         let buf = [0u8; 10];
         limiter.write(&buf).unwrap();
@@ -47,7 +47,7 @@ mod tests {
     #[test]
     fn test_burst() {
         let file = tempfile().unwrap();
-        let mut limiter = Limiter::new(file, 1, Duration::from_secs(1));
+        let mut limiter = Limiter::new(file, 1, Duration::from_secs(1), 1);
         // Write a first byte of 1 byte. Should be instant
         let now = std::time::Instant::now();
         let buf = [0u8; 1];
@@ -66,7 +66,7 @@ mod tests {
     #[test]
     fn tenko_limit() {
         let file = tempfile().unwrap();
-        let mut limiter = Limiter::new(file, 10 * 1024, Duration::from_secs(1));
+        let mut limiter = Limiter::new(file, 10 * 1024, Duration::from_secs(1), 12*1024);
         let now = std::time::Instant::now();
         let buf = [0u8; 11 * 1024];
         limiter.write(&buf).unwrap();
@@ -76,11 +76,20 @@ mod tests {
     #[test]
     fn splitted_read() {
         let file = tempfile().unwrap();
-        let mut limiter = Limiter::new(file, 11, Duration::from_nanos((1000 * 1000 * 1000) / 1024));
+        let mut limiter = Limiter::new(file, 11, Duration::from_nanos((1000 * 1000 * 1000) / 1024), 12*1024);
         let now = std::time::Instant::now();
         let buf = [0u8; 8];
         limiter.write(&buf).unwrap();
         let buf = [0u8; (11 * 1024) - 8];
+        limiter.write(&buf).unwrap();
+        assert_eq!(now.elapsed().as_secs(), 1);
+    }
+    #[test]
+    fn write_bucket_full() {
+        let file = tempfile().unwrap();
+        let mut limiter = Limiter::new(file, 1024, Duration::from_secs(1), 10);
+        let now = std::time::Instant::now();
+        let buf = [0u8; 15];
         limiter.write(&buf).unwrap();
         assert_eq!(now.elapsed().as_secs(), 1);
     }

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -47,7 +47,7 @@ mod tests {
     #[test]
     fn test_burst() {
         let file = tempfile().unwrap();
-        let mut limiter = Limiter::new(file, 1, Duration::from_secs(1), 1);
+        let mut limiter = Limiter::new(file, 1, Duration::from_secs(1), 9);
         // Write a first byte of 1 byte. Should be instant
         let now = std::time::Instant::now();
         let buf = [0u8; 1];

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -66,7 +66,7 @@ mod tests {
     #[test]
     fn tenko_limit() {
         let file = tempfile().unwrap();
-        let mut limiter = Limiter::new(file, 10 * 1024, Duration::from_secs(1), 12*1024);
+        let mut limiter = Limiter::new(file, 10 * 1024, Duration::from_secs(1), 12 * 1024);
         let now = std::time::Instant::now();
         let buf = [0u8; 11 * 1024];
         limiter.write(&buf).unwrap();
@@ -76,7 +76,12 @@ mod tests {
     #[test]
     fn splitted_read() {
         let file = tempfile().unwrap();
-        let mut limiter = Limiter::new(file, 11, Duration::from_nanos((1000 * 1000 * 1000) / 1024), 12*1024);
+        let mut limiter = Limiter::new(
+            file,
+            11,
+            Duration::from_nanos((1000 * 1000 * 1000) / 1024),
+            12 * 1024,
+        );
         let now = std::time::Instant::now();
         let buf = [0u8; 8];
         limiter.write(&buf).unwrap();


### PR DESCRIPTION
Closes #4 

Implements a size limit of the token bucket to avoid burst of read speed after a long wait