### PR TITLE
Ensure read/write operations outputs the correct data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,13 @@
 version = 3
 
 [[package]]
-name = "bitflags"
-version = "1.3.2"
+name = "block-buffer"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "cfg-if"
@@ -15,22 +18,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "fastrand"
-version = "1.9.0"
+name = "cpufeatures"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
- "instant",
+ "libc",
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
+name = "crypto-common"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "cfg-if",
+ "generic-array",
+ "typenum",
 ]
+
+[[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "libc"
@@ -39,62 +69,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
+name = "sha2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
 name = "stream_limiter"
 version = "1.2.0"
 dependencies = [
- "tempfile",
+ "hex-literal",
+ "sha2",
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.3.0"
+name = "typenum"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
-dependencies = [
- "cfg-if",
- "fastrand",
- "libc",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
-]
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
+name = "version_check"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ keywords = ["rate", "rate_limiting", "synchronous", "stream"]
 [dependencies]
 
 [dev-dependencies]
-tempfile = "3.3.0"
+sha2 = "0.10.6"
+hex-literal = "0.4.1"

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,0 +1,1 @@
+pub mod utils;

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -84,7 +84,6 @@ mod tests {
         let now = std::time::Instant::now();
         let mut buf = Vec::with_capacity(5);
         limiter.read_to_end(&mut buf).unwrap();
-        println!("{:?}", buf);
         assert_eq!(now.elapsed().as_secs(), 5);
         assert_checksum(&buf, &FILE_LITTLE);
     }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,0 +1,36 @@
+use hex_literal::hex;
+use sha2::Digest;
+
+// The checksum and the size of the data (to trim the buffer)
+pub const FILE_BIG: ([u8; 32], usize) = (
+    hex!("55e28ecbd9ea1df018ffacd137ee8d62551eb2d6fbd46508bca7809005ff267a"),
+    11264,
+);
+pub const FILE_LITTLE: ([u8; 32], usize) = (
+    hex!("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"),
+    4,
+);
+pub const FILE_TEST: ([u8; 32], usize) = (
+    hex!("f29bc64a9d3732b4b9035125fdb3285f5b6455778edca72414671e0ca3b2e0de"),
+    20,
+);
+
+pub fn assert_checksum(buf: &[u8], file: &([u8; 32], usize)) {
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(&buf[..file.1]);
+    assert_eq!(hasher.finalize()[..], file.0[..]);
+}
+
+pub fn assert_checksum_samedata<const N: usize>(buf: &[u8], data: u8) {
+    let mut hasher = sha2::Sha256::new();
+    let samedata = [data; N];
+    if N <= 50 {
+        println!("{:?}\n{:?}", samedata, buf);
+    }
+    hasher.update(&[data; N]);
+    let samedata_hash = hasher.finalize();
+
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(&buf);
+    assert_eq!(hasher.finalize()[..], samedata_hash[..]);
+}

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -9,7 +9,6 @@ mod tests {
     #[test]
     fn one_byte_each_second() {
         let outbuf = std::io::Cursor::new(vec![]);
-        // let file = tempfile().unwrap();
         let mut limiter = Limiter::new(outbuf, 1, Duration::from_secs(1), 10);
         let now = std::time::Instant::now();
         let buf = [42u8; 10];

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -1,56 +1,63 @@
+mod utils;
+
 mod tests {
     use std::{io::Write, time::Duration};
 
+    use super::utils::assert_checksum_samedata;
     use stream_limiter::Limiter;
-    use tempfile::tempfile;
 
     #[test]
     fn one_byte_each_second() {
-        let file = tempfile().unwrap();
-        let mut limiter = Limiter::new(file, 1, Duration::from_secs(1), 10);
+        let outbuf = std::io::Cursor::new(vec![]);
+        // let file = tempfile().unwrap();
+        let mut limiter = Limiter::new(outbuf, 1, Duration::from_secs(1), 10);
         let now = std::time::Instant::now();
-        let buf = [0u8; 10];
+        let buf = [42u8; 10];
         limiter.write(&buf).unwrap();
         assert_eq!(now.elapsed().as_secs(), 9);
+        assert_checksum_samedata::<10>(&limiter.stream.into_inner(), 42);
     }
 
     #[test]
     fn one_byte_each_two_hundreds_fifty_millis() {
-        let file = tempfile().unwrap();
-        let mut limiter = Limiter::new(file, 1, Duration::from_millis(250), 10);
+        let outbuf = std::io::Cursor::new(vec![]);
+        let mut limiter = Limiter::new(outbuf, 1, Duration::from_millis(250), 10);
         let now = std::time::Instant::now();
-        let buf = [0u8; 10];
+        let buf = [21u8; 10];
         limiter.write(&buf).unwrap();
         assert_eq!(now.elapsed().as_secs(), 2);
+        assert_checksum_samedata::<10>(&limiter.stream.into_inner(), 21);
     }
 
     #[test]
     fn two_byte_each_second() {
-        let file = tempfile().unwrap();
-        let mut limiter = Limiter::new(file, 2, Duration::from_secs(1), 10);
+        let outbuf = std::io::Cursor::new(vec![]);
+        let mut limiter = Limiter::new(outbuf, 2, Duration::from_secs(1), 10);
         let now = std::time::Instant::now();
-        let buf = [0u8; 10];
+        let buf = [18u8; 10];
         limiter.write(&buf).unwrap();
         assert_eq!(now.elapsed().as_secs(), 4);
+        assert_checksum_samedata::<10>(&limiter.stream.into_inner(), 18);
     }
 
     #[test]
     fn write_instant() {
-        let file = tempfile().unwrap();
-        let mut limiter = Limiter::new(file, 10, Duration::from_secs(1), 10);
+        let outbuf = std::io::Cursor::new(vec![]);
+        let mut limiter = Limiter::new(outbuf, 10, Duration::from_secs(1), 10);
         let now = std::time::Instant::now();
-        let buf = [0u8; 10];
+        let buf = [33u8; 10];
         limiter.write(&buf).unwrap();
         assert_eq!(now.elapsed().as_secs(), 0);
+        assert_checksum_samedata::<10>(&limiter.stream.into_inner(), 33);
     }
 
     #[test]
     fn test_burst() {
-        let file = tempfile().unwrap();
-        let mut limiter = Limiter::new(file, 1, Duration::from_secs(1), 9);
+        let outbuf = std::io::Cursor::new(vec![]);
+        let mut limiter = Limiter::new(outbuf, 1, Duration::from_secs(1), 9);
         // Write a first byte of 1 byte. Should be instant
         let now = std::time::Instant::now();
-        let buf = [0u8; 1];
+        let buf = [12u8; 1];
         limiter.write(&buf).unwrap();
         assert_eq!(now.elapsed().as_secs(), 0);
 
@@ -58,44 +65,49 @@ mod tests {
 
         // Write a second byte of 9 bytes. Should be instant because we waited above
         let now = std::time::Instant::now();
-        let buf = [0u8; 9];
+        let buf = [12u8; 9];
         limiter.write(&buf).unwrap();
         assert_eq!(now.elapsed().as_secs(), 0);
+        assert_checksum_samedata::<10>(&limiter.stream.into_inner(), 12);
     }
 
     #[test]
     fn tenko_limit() {
-        let file = tempfile().unwrap();
-        let mut limiter = Limiter::new(file, 10 * 1024, Duration::from_secs(1), 12 * 1024);
+        let outbuf = std::io::Cursor::new(vec![]);
+        let mut limiter = Limiter::new(outbuf, 10 * 1024, Duration::from_secs(1), 12 * 1024);
         let now = std::time::Instant::now();
-        let buf = [0u8; 11 * 1024];
+        let buf = [88u8; 11 * 1024];
         limiter.write(&buf).unwrap();
         assert_eq!(now.elapsed().as_secs(), 1);
+        assert_checksum_samedata::<11264>(&limiter.stream.into_inner(), 88);
     }
 
     #[test]
-    fn splitted_read() {
-        let file = tempfile().unwrap();
+    fn splitted_write() {
+        let outbuf = std::io::Cursor::new(vec![]);
         let mut limiter = Limiter::new(
-            file,
+            outbuf,
             11,
             Duration::from_nanos((1000 * 1000 * 1000) / 1024),
             12 * 1024,
         );
         let now = std::time::Instant::now();
-        let buf = [0u8; 8];
+        let buf = [66u8; 8];
         limiter.write(&buf).unwrap();
-        let buf = [0u8; (11 * 1024) - 8];
+        let buf = [66u8; (11 * 1024) - 8];
         limiter.write(&buf).unwrap();
         assert_eq!(now.elapsed().as_secs(), 1);
+        assert_checksum_samedata::<11264>(&limiter.stream.into_inner(), 66);
     }
+
     #[test]
     fn write_bucket_full() {
-        let file = tempfile().unwrap();
-        let mut limiter = Limiter::new(file, 1024, Duration::from_secs(1), 10);
+        let outbuf = std::io::Cursor::new(vec![]);
+        let mut limiter = Limiter::new(outbuf, 1024, Duration::from_secs(1), 10);
         let now = std::time::Instant::now();
-        let buf = [0u8; 15];
+        let buf = [128u8; 15];
         limiter.write(&buf).unwrap();
         assert_eq!(now.elapsed().as_secs(), 1);
+        assert_checksum_samedata::<15>(&limiter.stream.into_inner(), 128);
     }
 }


### PR DESCRIPTION
Fixes #8 

The data is now verified by checksum after each test

Use the `read` /  `write` internal counter to populate the whole buffer