### PR TITLE
Sleep to the instant of the next token, not the token length

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,11 @@ where
         while buf_left > 0 {
             let nb_bytes_readable = self.tokens_available().0.unwrap().min(buf_left);
             if nb_bytes_readable < readlimit.min(buf_left) {
-                std::thread::sleep(*window_time);
+                if let Some(lrc) = self.last_read_check {
+                    std::thread::sleep((*window_time - lrc.elapsed()).max(Duration::from_nanos(0)));
+                } else {
+                    std::thread::sleep(*window_time);
+                }
                 continue;
             }
             // Before reading so that we don't count the time it takes to read
@@ -198,7 +202,11 @@ where
         while buf_left > 0 {
             let nb_bytes_writable = self.tokens_available().1.unwrap().min(buf_left);
             if nb_bytes_writable < writelimit.min(buf_left) {
-                std::thread::sleep(*window_time);
+                if let Some(lwc) = self.last_write_check {
+                    std::thread::sleep((*window_time - lwc.elapsed()).max(Duration::from_nanos(0)));
+                } else {
+                    std::thread::sleep(*window_time);
+                }
                 continue;
             }
             // Before reading so that we don't count the time it takes to read

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,11 +162,13 @@ where
         while buf_left > 0 {
             let nb_bytes_readable = self.tokens_available().0.unwrap().min(buf_left);
             if nb_bytes_readable < readlimit.min(buf_left) {
-                if let Some(lrc) = self.last_read_check {
-                    std::thread::sleep((*window_time - lrc.elapsed()).max(Duration::from_nanos(0)));
+                let elapsed = if let Some(lrc) = self.last_read_check {
+                    lrc.elapsed()
                 } else {
-                    std::thread::sleep(*window_time);
-                }
+                    Duration::ZERO
+                };
+                self.last_read_check = Some(std::time::Instant::now());
+                std::thread::sleep(window_time.saturating_sub(elapsed));
                 continue;
             }
             // Before reading so that we don't count the time it takes to read
@@ -202,11 +204,13 @@ where
         while buf_left > 0 {
             let nb_bytes_writable = self.tokens_available().1.unwrap().min(buf_left);
             if nb_bytes_writable < writelimit.min(buf_left) {
-                if let Some(lwc) = self.last_write_check {
-                    std::thread::sleep((*window_time - lwc.elapsed()).max(Duration::from_nanos(0)));
+                let elapsed = if let Some(lwc) = self.last_write_check {
+                    lwc.elapsed()
                 } else {
-                    std::thread::sleep(*window_time);
-                }
+                    Duration::ZERO
+                };
+                self.last_write_check = Some(std::time::Instant::now());
+                std::thread::sleep(window_time.saturating_sub(elapsed));
                 continue;
             }
             // Before reading so that we don't count the time it takes to read


### PR DESCRIPTION
Closes #5 

Instead of sleeping for the duration of a whole token, sleep until the next token is available.
Based over #10 , waiting for it to be merged before merging this one, but still ready for review