### PR TITLE
Add some tests to debug inconsistencies when using network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "stream_limiter"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "hex-literal",
  "sha2",

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -28,7 +28,7 @@ mod tests {
             let mut buffer = [0u8; 10];
             let now = std::time::Instant::now();
             limiter.read(&mut buffer).unwrap();
-            println!("R] Result: {:?}", buffer);
+            println!("R] Result: {:?} (len {})", buffer, buffer.len());
             assert_eq!(buffer, [42; 10]);
             assert_eq!(now.elapsed().as_secs(), 1);
             break;
@@ -55,11 +55,11 @@ mod tests {
             let mut stream = stream.unwrap();
             println!("R] Stream {:?} connected", stream);
             println!("R] Reading with limitation");
-            let mut buffer = Vec::new();
+            let mut buffer = [0; 10];
             let now = std::time::Instant::now();
-            stream.read_to_end(&mut buffer).unwrap();
+            stream.read_exact(&mut buffer).unwrap();
 
-            println!("R] Result: {:?}", buffer);
+            println!("R] Result: {:?} (len {})", buffer, buffer.len());
             assert_eq!(buffer, [42; 10]);
             assert_eq!(now.elapsed().as_secs(), 1);
             break;
@@ -85,16 +85,16 @@ mod tests {
         for stream in listener.incoming() {
             println!("R] Stream {:?} connected", stream);
             println!("R] Reading with limitation");
-            let mut buffer = Vec::new();
+            let mut buffer = [0; 10];
             let now = std::time::Instant::now();
             let mut limiter = Limiter::new(
                 stream.unwrap(),
                 Some(LimiterOptions::new(9, Duration::from_secs(1), 10)),
                 None,
             );
-            limiter.read_to_end(&mut buffer).unwrap();
+            limiter.read_exact(&mut buffer).unwrap();
 
-            println!("R] Result: {:?}", buffer);
+            println!("R] Result: {:?} (len {})", buffer, buffer.len());
             assert_eq!(buffer, [42; 10]);
             assert_eq!(now.elapsed().as_secs(), 1);
             break;
@@ -120,18 +120,18 @@ mod tests {
         for stream in listener.incoming() {
             println!("R] Stream {:?} connected", stream);
             println!("R] Reading with limitation");
-            let mut buffer = Vec::new();
+            let mut buffer = [0; 10];
             let now = std::time::Instant::now();
             let mut limiter = Limiter::new(
                 stream.unwrap(),
                 Some(LimiterOptions::new(10, Duration::from_secs(1), 10)),
                 None,
             );
-            limiter.read_to_end(&mut buffer).unwrap();
+            limiter.read_exact(&mut buffer).unwrap();
 
-            println!("R] Result: {:?}", buffer);
+            println!("R] Result: {:?} (len {})", buffer, buffer.len());
             assert_eq!(buffer, [42; 10]);
-            assert_eq!(now.elapsed().as_secs(), 1);
+            assert_eq!(now.elapsed().as_secs(), 0);
             break;
         }
     }

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -1,0 +1,138 @@
+mod utils;
+
+mod tests {
+    use stream_limiter::{Limiter, LimiterOptions};
+    use std::net::{TcpListener, TcpStream};
+    use std::io::{Read, Write};
+    use std::time::Duration;
+
+    #[test]
+    fn test_limit_read() {
+        let listener = TcpListener::bind("127.0.0.1:34254").unwrap();
+        std::thread::spawn(|| {
+            println!("W] Connecting...");
+            let mut stream = TcpStream::connect("127.0.0.1:34254").unwrap();
+            println!("W] Writing ...");
+            stream.write(&[42u8; 10]).unwrap();
+            println!("W] OK");
+        });
+        println!("R] Listening ...");
+        for stream in listener.incoming() {
+            println!("R] Stream {:?} connected", stream);
+            let mut limiter = Limiter::new(
+                stream.unwrap(),
+                Some(LimiterOptions::new(9, Duration::from_secs(1), 10)),
+                None,
+            );
+            println!("R] Reading with limitation");
+            let mut buffer = [0u8; 10];
+            let now = std::time::Instant::now();
+            limiter.read(&mut buffer).unwrap();
+            println!("R] Result: {:?}", buffer);
+            assert_eq!(buffer, [42; 10]);
+            assert_eq!(now.elapsed().as_secs(), 1);
+            break;
+        }
+    }
+
+    #[test]
+    fn test_limit_write() {
+        let listener = TcpListener::bind("127.0.0.1:34255").unwrap();
+        std::thread::spawn(|| {
+            println!("W] Connecting...");
+            let stream = TcpStream::connect("127.0.0.1:34255").unwrap();
+            let mut limiter = Limiter::new(
+                stream,
+                None,
+                Some(LimiterOptions::new(9, Duration::from_secs(1), 10)),
+            );
+            println!("W] Writing ...");
+            limiter.write(&[42u8; 10]).unwrap();
+            println!("W] OK");
+        });
+        println!("R] Listening ...");
+        for stream in listener.incoming() {
+            let mut stream = stream.unwrap();
+            println!("R] Stream {:?} connected", stream);
+            println!("R] Reading with limitation");
+            let mut buffer = Vec::new();
+            let now = std::time::Instant::now();
+            stream.read_to_end(&mut buffer).unwrap();
+
+            println!("R] Result: {:?}", buffer);
+            assert_eq!(buffer, [42; 10]);
+            assert_eq!(now.elapsed().as_secs(), 1);
+            break;
+        }
+    }
+
+    #[test]
+    fn test_limit_both() {
+        let listener = TcpListener::bind("127.0.0.1:34256").unwrap();
+        std::thread::spawn(|| {
+            println!("W] Connecting...");
+            let stream = TcpStream::connect("127.0.0.1:34256").unwrap();
+            let mut limiter = Limiter::new(
+                stream,
+                None,
+                Some(LimiterOptions::new(9, Duration::from_secs(1), 10)),
+            );
+            println!("W] Writing ...");
+            limiter.write_all(&[42u8; 10]).unwrap();
+            println!("W] OK");
+        });
+        println!("R] Listening ...");
+        for stream in listener.incoming() {
+            println!("R] Stream {:?} connected", stream);
+            println!("R] Reading with limitation");
+            let mut buffer = Vec::new();
+            let now = std::time::Instant::now();
+            let mut limiter = Limiter::new(
+                stream.unwrap(),
+                Some(LimiterOptions::new(9, Duration::from_secs(1), 10)),
+                None,
+            );
+            limiter.read_to_end(&mut buffer).unwrap();
+
+            println!("R] Result: {:?}", buffer);
+            assert_eq!(buffer, [42; 10]);
+            assert_eq!(now.elapsed().as_secs(), 1);
+            break;
+        }
+    }
+
+    #[test]
+    fn test_peak_both() {
+        let listener = TcpListener::bind("127.0.0.1:34257").unwrap();
+        std::thread::spawn(|| {
+            println!("W] Connecting...");
+            let stream = TcpStream::connect("127.0.0.1:34257").unwrap();
+            let mut limiter = Limiter::new(
+                stream,
+                None,
+                Some(LimiterOptions::new(10, Duration::from_secs(1), 10)),
+            );
+            println!("W] Writing ...");
+            limiter.write_all(&[42u8; 10]).unwrap();
+            println!("W] OK");
+        });
+        println!("R] Listening ...");
+        for stream in listener.incoming() {
+            println!("R] Stream {:?} connected", stream);
+            println!("R] Reading with limitation");
+            let mut buffer = Vec::new();
+            let now = std::time::Instant::now();
+            let mut limiter = Limiter::new(
+                stream.unwrap(),
+                Some(LimiterOptions::new(10, Duration::from_secs(1), 10)),
+                None,
+            );
+            limiter.read_to_end(&mut buffer).unwrap();
+
+            println!("R] Result: {:?}", buffer);
+            assert_eq!(buffer, [42; 10]);
+            assert_eq!(now.elapsed().as_secs(), 1);
+            break;
+        }
+    }
+}


### PR DESCRIPTION
Problems are occurring when using the Limiter with the network.
To debug this, I created some tests to ensure the correct behaviour.

## test_limit_read
The Receiver is limiting the speed, but the Writer writes the stream directly.
This test is **OK**

## test_limit_write
The Writer is limiting the speed, but the Receiver reads the stream directly.
This test is **OK IF** we use the function `read_to_end` and not `read` on the Receiver

## test_limit_both
The Writer and the Receiver are limiting the speed with the same configuration.
The test **FAILS**. If the Receiver's limit is `X token per second`, only X tokens will be received.
So when expecting a buffer of size 10, with a Limiter that limits to `9 bytes/sec`, we only read `9` bytes, nothing more.

## test_peak_both
The Writer and Receiver are limiting the speed with the same configuration.
The rate limit is higher than the size of the data transmitted, and so shouldn't affect the speed of the transmission.
The test **FAILS**, the output buffer is empty.
If the limit (per seconds) is the same size as the expected buffer, it transmits fine but takes `2 secs` where it should go instantly.