### PR TITLE
Add a timeout option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "stream_limiter"
-version = "3.0.1"
+version = "3.1.1"
 dependencies = [
  "hex-literal",
  "rand",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,11 +336,6 @@ where
                     .saturating_sub(nb_bytes_writable)
                     .try_into()
                     .expect("Write nb left > u32::MAX");
-                println!(
-                    "{nb_left} bytes needed, {:?} per byte, sleep {:?}",
-                    opts.tsleep,
-                    opts.tsleep * nb_left
-                );
                 let tsleep_total = if let Some(t) = opts.timeout {
                     (opts.tsleep * nb_left).min(t.saturating_sub(write_start.elapsed()))
                 } else {
@@ -368,7 +363,6 @@ where
             let write_start = usize::try_from(write).expect("W write_start to usize");
             let write_end = usize::try_from(write.saturating_add(nb_bytes_writable.min(buf_left)))
                 .expect("W write_end to usize");
-            println!("Writing {} bytes", nb_bytes_writable.min(buf_left));
 
             #[cfg(test)]
             let write_start_instant = std::time::Instant::now();

--- a/src/tests/parametric.rs
+++ b/src/tests/parametric.rs
@@ -1,3 +1,5 @@
+// TODO     Add random timeout on the tests as well
+
 use sha2::Digest;
 use std::{
     io::{Read, Write},

--- a/src/tests/read.rs
+++ b/src/tests/read.rs
@@ -174,4 +174,19 @@ fn test_max_limit() {
     assert_checksum(&buf, &FILE_BIG);
 }
 
+#[test]
+fn read_timeout() {
+    let file = open_file("big.txt");
+    let mut limopt = LimiterOptions::new(1, Duration::from_secs(1), 10);
+    limopt.set_timeout(Duration::from_secs(1));
+    let mut limiter = Limiter::new(file, Some(limopt), None);
+    assert!(limiter.limits().0);
+
+    let mut buf = [0u8; 11 * 1024];
+    let now = std::time::Instant::now();
+    let res = limiter.read(&mut buf);
+    assert_eq!(now.elapsed().as_millis(), 1000);
+    assert!(res.is_err());
+}
+
 // TODO    Add test changing the bucket size between 2 reads

--- a/src/tests/write.rs
+++ b/src/tests/write.rs
@@ -159,3 +159,18 @@ fn test_max_limit() {
 
     assert_checksum_samedata::<100>(&limiter.stream.into_inner(), 144);
 }
+
+#[test]
+fn write_timeout() {
+    let outbuf = std::io::Cursor::new(vec![]);
+    let mut limopt = LimiterOptions::new(1, Duration::from_secs(1), 10);
+    limopt.set_timeout(Duration::from_secs(1));
+    let mut limiter = Limiter::new(outbuf, None, Some(limopt));
+    assert!(limiter.limits().1);
+
+    let mut buf = [128u8; 110];
+    let now = std::time::Instant::now();
+    let res = limiter.write(&mut buf);
+    assert_eq!(now.elapsed().as_millis(), 1000);
+    assert!(res.is_err());
+}


### PR DESCRIPTION
Implements a timeout in the `read` / `write` functions that will raise an error when the provided Duration is expired.

Required for https://github.com/massalabs/PeerNet/pull/55 as the stream_limiter breaks the timeout when set directly on the stream.